### PR TITLE
fix: Atualizar actions/upload-artifact deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           name: codecov-umbrella
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results


### PR DESCRIPTION
Atualizar versão deprecated de actions/upload-artifact@v3 para v4

Closes #6